### PR TITLE
fix matching pattern bugs

### DIFF
--- a/lib/matcher.js
+++ b/lib/matcher.js
@@ -29,7 +29,7 @@ const {suffixes} = require("./domain");
  * Regular expression for matching a keyword in a filter.
  * @type {RegExp}
  */
-const keywordRegExp = /[^a-z0-9%*][a-z0-9%]{3,}(?=[^a-z0-9%*])/;
+const keywordRegExp = /[^\w\-%*][\w\-%]+(?=[^\w\-%*])/;
 
 /**
  * Regular expression for matching all keywords in a filter.
@@ -531,7 +531,7 @@ class Matcher
    */
   matchesAny(location, typeMask, docDomain, thirdParty, sitekey, specificOnly)
   {
-    let candidates = location.toLowerCase().match(/[a-z0-9%]{3,}/g);
+    let candidates = location.toLowerCase().match(/[\w\-%]+/g);
     if (candidates === null)
       candidates = [];
     candidates.push("");
@@ -648,7 +648,7 @@ class CombinedMatcher
   _matchesAnyInternal(location, typeMask, docDomain, thirdParty, sitekey,
                       specificOnly)
   {
-    let candidates = location.toLowerCase().match(/[a-z0-9%]{3,}/g);
+    let candidates = location.toLowerCase().match(/[\w\-%]+/g);
     if (candidates === null)
       candidates = [];
 
@@ -711,7 +711,7 @@ class CombinedMatcher
     if ((typeMask & ~WHITELIST_ONLY_TYPES) == 0)
       searchBlocking = false;
 
-    let candidates = location.toLowerCase().match(/[a-z0-9%]{3,}/g);
+    let candidates = location.toLowerCase().match(/[\w\-%]+/g);
     if (candidates === null)
       candidates = [];
     candidates.push("");


### PR DESCRIPTION
example:
||t.me <--> https://t.me
||xn--fsqu00a.xn--3lr804guic <--> http://xn--fsqu00a.xn--3lr804guic/

https://github.com/gorhill/uBlock/issues/3717